### PR TITLE
Add a block around the contact submit action

### DIFF
--- a/ckanext/contact/theme/templates/contact/snippets/form.html
+++ b/ckanext/contact/theme/templates/contact/snippets/form.html
@@ -24,8 +24,10 @@
       </fieldset>
 
       <div class="form-actions">
-        {{ form.required_message() }}
-        <button class="btn btn-primary save" type="submit" name="save">{{ _('Submit') }}</button>
+        {% block contact_form_actions %}
+            {{ form.required_message() }}
+            <button class="btn btn-primary save" type="submit" name="save">{{ _('Submit') }}</button>
+        {% endblock %}
       </div>
     </form>
 


### PR DESCRIPTION
Allows extension of this block by other extensions.

Required by https://github.com/NaturalHistoryMuseum/ckanext-nhm/pull/394 