### PR TITLE
Add prefix to subject from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ These are the options that can be specified in your .ini config file.
 | `ckanext.contact.recipient_name`           | Name of the recipient                             | `ckan.site_title`               |
 | `ckanext.contact.subject`                  | Email subject for the submitted form              | 'Contact/Question from visitor' |
 | `ckanext.contact.add_timestamp_to_subject` | Whether to append a timestamp to the subject line | `false`                         |
+| `ckanext.contact.subject_prefix`           | A prefix to add to the subject before sending     | ''                              |
 
 ## Recaptcha
 

--- a/ckanext/contact/routes/_helpers.py
+++ b/ckanext/contact/routes/_helpers.py
@@ -80,7 +80,10 @@ def build_subject(
     ):
         timestamp = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S %Z')
         subject = f'{subject} [{timestamp}]'
-    return subject
+
+    prefix = toolkit.config.get('ckanext.contact.subject_prefix', '')
+
+    return f'{prefix}{subject}'
 
 
 def submit():

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -73,3 +73,12 @@ class TestBuildSubject:
     def test_config_with_timestamp(self):
         subject = build_subject()
         assert subject == 'TEST SUBJECT'
+
+    def test_prefix_not_provided(self):
+        subject = build_subject(subject='TEST')
+        assert subject == 'TEST'
+
+    @pytest.mark.ckan_config('ckanext.contact.subject_prefix', 'PREFIX: ')
+    def test_prefix_provided(self):
+        subject = build_subject(subject='TEST')
+        assert subject == 'PREFIX: TEST'


### PR DESCRIPTION
Closes https://github.com/NaturalHistoryMuseum/ckanext-nhm/issues/652

Needs to be set to `Data Portal Enquiry: ` in the portal config. The default is blank if the config option is not set which maintains current functionality.