### PR TITLE
fix: expect no trailing space in the prefix from config

### DIFF
--- a/ckanext/contact/routes/_helpers.py
+++ b/ckanext/contact/routes/_helpers.py
@@ -83,7 +83,7 @@ def build_subject(
 
     prefix = toolkit.config.get('ckanext.contact.subject_prefix', '')
 
-    return f'{prefix}{subject}'
+    return f'{prefix}{" " if prefix else ""}{subject}'
 
 
 def submit():

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -78,7 +78,7 @@ class TestBuildSubject:
         subject = build_subject(subject='TEST')
         assert subject == 'TEST'
 
-    @pytest.mark.ckan_config('ckanext.contact.subject_prefix', 'PREFIX: ')
+    @pytest.mark.ckan_config('ckanext.contact.subject_prefix', 'PREFIX:')
     def test_prefix_provided(self):
         subject = build_subject(subject='TEST')
         assert subject == 'PREFIX: TEST'


### PR DESCRIPTION
The setting in the ini file can't have a trailing space and there's no way of including it using quotes, so just add one always if we have a prefix set.