### PR TITLE
Remove unnecessary markdown message in request field

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Add the following HTML where you want the contact button to appear:
     <i class="fas fa-envelope"></i>{{ link_text if link_text else _('CONTACT BUTTON TEXT') }}
 </a>
 
-{% resource 'ckanext-contact/main' %}
+{% asset 'ckanext-contact/main' %}
 ```
 
 Where `params` is a dict with three entries: package_id, resource_id, record_id (all of which are optional).

--- a/ckanext/contact/theme/templates/contact/snippets/form.html
+++ b/ckanext/contact/theme/templates/contact/snippets/form.html
@@ -30,7 +30,7 @@
                               value=data.subject, error=errors.subject, classes=['control-medium'],
                               is_required=false, placeholder=_('Optional subject')) }}
 
-                {{ form.markdown('content', label=_('Your Request'), id='field-content',
+                {{ form.textarea('content', label=_('Your Request'), id='field-content',
                                  value=data.content, error=errors.content,
                                  placeholder=_('What do you have to tell us?'), is_required=true) }}
             {% endblock %}


### PR DESCRIPTION
I'd like to remove the unnecessary "You can use Markdown formatting here" message from the "Your Request" field in the contact form.

From my experience the email recipient only ever sees raw unformatted markdown text.

Also updated the instructions in the README file, replacing 'resources' with 'assets'. 
In v2.9+ it crashes with the 'resources' tag.